### PR TITLE
Fixed `get_AllowsCachingPolicies method not found` issue on executing application

### DIFF
--- a/src/DfE.CoreLibs.Security/DfE.CoreLibs.Security.csproj
+++ b/src/DfE.CoreLibs.Security/DfE.CoreLibs.Security.csproj
@@ -16,8 +16,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Authorization" Version="9.0.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.11" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
 		<PackageReference Include="Microsoft.Identity.Web" Version="3.4.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
Fixed get_AllowsCachingPolicies method not found issue by downgrading following NuGet versions from version 9.0.0 to 8.0.11. 
- Microsoft.AspNetCore.Authorization
- Microsoft.Extensions.DependencyInjection.Abstractions
