### PR TITLE
fixed feature branch check-out issue

### DIFF
--- a/.github/workflows/nuget-package-template.yml
+++ b/.github/workflows/nuget-package-template.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        repository: ${{ github.event.workflow_run.head_repository.full_name }}
+        ref: ${{ github.event.workflow_run.head_branch }}
         fetch-depth: 0
 
     - name: Setup .NET


### PR DESCRIPTION
Fixed an issue where the main branch is being checked out   instead of the feature branch when a prerelease package need to be built