### PR TITLE
Downgrade LogLevel for notices

### DIFF
--- a/src/DfE.CoreLibs.Http/Middlewares/CorrelationId/CorrelationIdMiddleware.cs
+++ b/src/DfE.CoreLibs.Http/Middlewares/CorrelationId/CorrelationIdMiddleware.cs
@@ -34,7 +34,7 @@ public class CorrelationIdMiddleware
             if (!Guid.TryParse(httpContext.Request.Headers[Keys.HeaderKey], out thisCorrelationId))
             {
                 thisCorrelationId = Guid.NewGuid();
-                _logger.LogWarning("Detected header x-correlationId, but value cannot be parsed to a GUID. Other values are not supported. Generated a new one: {CorrelationId}", thisCorrelationId);
+                _logger.LogInformation("Detected header x-correlationId, but value cannot be parsed to a GUID. Other values are not supported. Generated a new one: {CorrelationId}", thisCorrelationId);
             }
             else
             {
@@ -44,7 +44,7 @@ public class CorrelationIdMiddleware
         else
         {
             thisCorrelationId = Guid.NewGuid();
-            _logger.LogWarning("CorrelationIdMiddleware:Invoke - x-correlationId not detected in request headers. Generated a new one: {CorrelationId}", thisCorrelationId);
+            _logger.LogInformation("CorrelationIdMiddleware:Invoke - x-correlationId not detected in request headers. Generated a new one: {CorrelationId}", thisCorrelationId);
         }
 
         if (thisCorrelationId == Guid.Empty)

--- a/src/Tests/DfE.CoreLibs.Http.Tests/Middlewares/CorrelationIdMiddlewareTests.cs
+++ b/src/Tests/DfE.CoreLibs.Http.Tests/Middlewares/CorrelationIdMiddlewareTests.cs
@@ -100,7 +100,7 @@ namespace DfE.CoreLibs.Http.Tests.Middlewares
 
             // Assert
             _logger.Received(1).Log(
-                LogLevel.Warning,
+                LogLevel.Information,
                 Arg.Any<EventId>(),
                 Arg.Is<object>(v => v.ToString().Contains("Detected header x-correlationId, but value cannot be parsed to a GUID")),
                 Arg.Any<Exception>(),


### PR DESCRIPTION
Convert LogError to LogInformation which is more appropriate for  these log entries as technically an 'error' has not occured.