### PR TITLE
Database applications settings packagae

### DIFF
--- a/.github/workflows/build-deploy-aplication-settings.yml
+++ b/.github/workflows/build-deploy-aplication-settings.yml
@@ -1,0 +1,30 @@
+name: CI & Pack GovUK.Dfe.CoreLibs.ApplicationSettings
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "src/GovUK.Dfe.CoreLibs.ApplicationSettings/**"
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "src/GovUK.Dfe.CoreLibs.ApplicationSettings/**"
+
+jobs:
+  build-and-test:
+    uses: ./.github/workflows/build-test-template.yml
+    with:
+      project_name: GovUK.Dfe.CoreLibs.ApplicationSettings
+      project_path: src/GovUK.Dfe.CoreLibs.ApplicationSettings
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  pack-and-release:
+    needs: build-and-test
+    if: needs.build-and-test.result == 'success'
+    uses: ./.github/workflows/pack-template.yml
+    with:
+      project_name: GovUK.Dfe.CoreLibs.ApplicationSettings
+      project_path: src/GovUK.Dfe.CoreLibs.ApplicationSettings/GovUK.Dfe.CoreLibs.ApplicationSettings.csproj
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/GovUK.Dfe.CoreLibs.sln
+++ b/GovUK.Dfe.CoreLibs.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.10.35122.118
+# Visual Studio Version 18
+VisualStudioVersion = 18.4.11605.240
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GovUK.Dfe.CoreLibs.Caching", "src\GovUK.Dfe.CoreLibs.Caching\GovUK.Dfe.CoreLibs.Caching.csproj", "{D88D58F0-18C4-4C3B-805B-8A483500E73E}"
 EndProject
@@ -48,6 +48,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GovUK.Dfe.CoreLibs.Messaging.MassTransit", "src\GovUK.Dfe.CoreLibs.Messaging.MassTransit\GovUK.Dfe.CoreLibs.Messaging.MassTransit.csproj", "{B4EBEB86-ED60-4E4D-BDF2-DAB06CF54E84}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GovUK.Dfe.CoreLibs.Messaging.MassTransit.Tests", "src\Tests\GovUK.Dfe.CoreLibs.Messaging.MassTransit.Tests\GovUK.Dfe.CoreLibs.Messaging.MassTransit.Tests.csproj", "{1EA0F5A0-759C-4FF5-8C2C-CF4D4ACE252F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUK.Dfe.CoreLibs.ApplicationSettings", "src\GovUK.Dfe.CoreLibs.ApplicationSettings\GovUK.Dfe.CoreLibs.ApplicationSettings.csproj", "{7EA4DA7D-AA0D-F78A-E03A-64C584868F78}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUK.Dfe.CoreLibs.ApplicationSettings.Tests", "src\Tests\GovUK.Dfe.CoreLibs.ApplicationSettings.Tests\GovUK.Dfe.CoreLibs.ApplicationSettings.Tests.csproj", "{EA11C968-CDF4-6F99-F7B2-8DB18B5793F4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -142,6 +146,14 @@ Global
 		{1EA0F5A0-759C-4FF5-8C2C-CF4D4ACE252F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1EA0F5A0-759C-4FF5-8C2C-CF4D4ACE252F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1EA0F5A0-759C-4FF5-8C2C-CF4D4ACE252F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7EA4DA7D-AA0D-F78A-E03A-64C584868F78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7EA4DA7D-AA0D-F78A-E03A-64C584868F78}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7EA4DA7D-AA0D-F78A-E03A-64C584868F78}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7EA4DA7D-AA0D-F78A-E03A-64C584868F78}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EA11C968-CDF4-6F99-F7B2-8DB18B5793F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EA11C968-CDF4-6F99-F7B2-8DB18B5793F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA11C968-CDF4-6F99-F7B2-8DB18B5793F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA11C968-CDF4-6F99-F7B2-8DB18B5793F4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -156,6 +168,7 @@ Global
 		{8D3F0E0F-9C7F-6B1F-BD5C-3E4F5A6B7C8D} = {3F89DCAD-8EC7-41ED-A08F-A9EFAE263EB4}
 		{1F2A3B4C-5D6E-7F8A-9B0C-1D2E3F4A5B6C} = {3F89DCAD-8EC7-41ED-A08F-A9EFAE263EB4}
 		{1EA0F5A0-759C-4FF5-8C2C-CF4D4ACE252F} = {3F89DCAD-8EC7-41ED-A08F-A9EFAE263EB4}
+		{EA11C968-CDF4-6F99-F7B2-8DB18B5793F4} = {3F89DCAD-8EC7-41ED-A08F-A9EFAE263EB4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {01D11FBC-6C66-43E4-8F1F-46B105EDD95C}

--- a/src/GovUK.Dfe.CoreLibs.ApplicationSettings/Configuration/ApplicationSettingsOptions.cs
+++ b/src/GovUK.Dfe.CoreLibs.ApplicationSettings/Configuration/ApplicationSettingsOptions.cs
@@ -1,0 +1,26 @@
+namespace GovUK.Dfe.CoreLibs.ApplicationSettings.Configuration;
+
+public class ApplicationSettingsOptions
+{
+    public const string ConfigurationSection = "ApplicationSettings";
+
+    /// <summary>
+    /// Database schema name for the ApplicationSettings table
+    /// </summary>
+    public string? Schema { get; set; } = null;
+
+    /// <summary>
+    /// Enable caching of settings in memory
+    /// </summary>
+    public bool EnableCaching { get; set; } = true;
+
+    /// <summary>
+    /// Cache expiration time in minutes
+    /// </summary>
+    public int CacheExpirationMinutes { get; set; } = 30;
+
+    /// <summary>
+    /// Default category for settings without specified category
+    /// </summary>
+    public string DefaultCategory { get; set; } = "General";
+}

--- a/src/GovUK.Dfe.CoreLibs.ApplicationSettings/Data/ApplicationSettingsDbContext.cs
+++ b/src/GovUK.Dfe.CoreLibs.ApplicationSettings/Data/ApplicationSettingsDbContext.cs
@@ -1,0 +1,28 @@
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Configuration;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Entities;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace GovUK.Dfe.CoreLibs.ApplicationSettings.Data;
+
+public class ApplicationSettingsDbContext : DbContext
+{
+    private readonly ApplicationSettingsOptions _options;
+
+    public ApplicationSettingsDbContext(DbContextOptions<ApplicationSettingsDbContext> options, IOptions<ApplicationSettingsOptions> settingsOptions)
+        : base(options)
+    {
+        _options = settingsOptions.Value;
+    }
+
+    public DbSet<ApplicationSetting> ApplicationSettings { get; set; } = null!;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        // Use the extension method for configuration
+        modelBuilder.ConfigureApplicationSettings(_options);
+
+        base.OnModelCreating(modelBuilder);
+    }
+}

--- a/src/GovUK.Dfe.CoreLibs.ApplicationSettings/Entities/ApplicationSetting.cs
+++ b/src/GovUK.Dfe.CoreLibs.ApplicationSettings/Entities/ApplicationSetting.cs
@@ -1,0 +1,15 @@
+namespace GovUK.Dfe.CoreLibs.ApplicationSettings.Entities;
+
+public class ApplicationSetting
+{
+    public int Id { get; set; }
+    public string Key { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string Category { get; set; } = "General";
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    public string? CreatedBy { get; set; }
+    public string? UpdatedBy { get; set; }
+    public bool IsActive { get; set; } = true;
+}

--- a/src/GovUK.Dfe.CoreLibs.ApplicationSettings/Extensions/DbContextExtensions.cs
+++ b/src/GovUK.Dfe.CoreLibs.ApplicationSettings/Extensions/DbContextExtensions.cs
@@ -1,0 +1,83 @@
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Configuration;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUK.Dfe.CoreLibs.ApplicationSettings.Extensions;
+
+public static class DbContextExtensions
+{
+    /// <summary>
+    /// Adds ApplicationSettings entity configuration to an existing DbContext
+    /// </summary>
+    /// <param name="modelBuilder">The ModelBuilder instance</param>
+    /// <param name="schema">Optional schema name. If null, uses default schema</param>
+    /// <param name="tableName">Optional table name. Defaults to "ApplicationSettings"</param>
+    public static void ConfigureApplicationSettings(
+        this ModelBuilder modelBuilder,
+        string? schema = null,
+        string tableName = "ApplicationSettings")
+    {
+        // Apply default schema if specified
+        if (!string.IsNullOrEmpty(schema))
+        {
+            modelBuilder.HasDefaultSchema(schema);
+        }
+
+        modelBuilder.Entity<ApplicationSetting>(entity =>
+        {
+            // Configure table with optional schema
+            if (!string.IsNullOrEmpty(schema))
+            {
+                entity.ToTable(tableName, schema);
+            }
+            else
+            {
+                entity.ToTable(tableName);
+            }
+
+            entity.HasKey(e => e.Id);
+
+            entity.Property(e => e.Key)
+                .IsRequired()
+                .HasMaxLength(255);
+
+            entity.Property(e => e.Value)
+                .IsRequired();
+
+            entity.Property(e => e.Description)
+                .HasMaxLength(500);
+
+            entity.Property(e => e.Category)
+                .IsRequired()
+                .HasMaxLength(100)
+                .HasDefaultValue("General");
+
+            entity.Property(e => e.CreatedBy)
+                .HasMaxLength(255);
+
+            entity.Property(e => e.UpdatedBy)
+                .HasMaxLength(255);
+
+            // Create unique index on Key for fast lookups
+            entity.HasIndex(e => e.Key)
+                .IsUnique()
+                .HasDatabaseName("IX_ApplicationSettings_Key");
+
+            // Create index on Category for filtered queries
+            entity.HasIndex(e => e.Category)
+                .HasDatabaseName("IX_ApplicationSettings_Category");
+        });
+    }
+
+    /// <summary>
+    /// Adds ApplicationSettings entity configuration using options from DI
+    /// </summary>
+    /// <param name="modelBuilder">The ModelBuilder instance</param>
+    /// <param name="options">ApplicationSettings options</param>
+    public static void ConfigureApplicationSettings(
+        this ModelBuilder modelBuilder,
+        ApplicationSettingsOptions options)
+    {
+        modelBuilder.ConfigureApplicationSettings(options.Schema, "ApplicationSettings");
+    }
+}

--- a/src/GovUK.Dfe.CoreLibs.ApplicationSettings/Extensions/ServiceCollectionExtensions.cs
+++ b/src/GovUK.Dfe.CoreLibs.ApplicationSettings/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,157 @@
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Configuration;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Data;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Interfaces;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GovUK.Dfe.CoreLibs.ApplicationSettings.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    // Group all AddApplicationSettings overloads together
+    public static IServiceCollection AddApplicationSettings(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string connectionStringName = "DefaultConnection",
+        string? schema = null)
+    {
+        // Configure options using shared method
+        services.ConfigureApplicationSettingsOptions(configuration, schema);
+
+        // Add DbContext
+        services.AddDbContext<ApplicationSettingsDbContext>(options =>
+            options.UseSqlServer(configuration.GetConnectionString(connectionStringName)));
+
+        // Add shared dependencies and service
+        return services.AddApplicationSettingsCore<ApplicationSettingsService>();
+    }
+
+    public static IServiceCollection AddApplicationSettings(
+        this IServiceCollection services,
+        string connectionString,
+        Action<ApplicationSettingsOptions>? configureOptions = null)
+    {
+        // Configure options with defaults and optional customization
+        services.Configure<ApplicationSettingsOptions>(options =>
+        {
+            // Set defaults using shared method
+            SetDefaultOptions(options);
+
+            // Apply custom configuration if provided
+            configureOptions?.Invoke(options);
+        });
+
+        // Add DbContext
+        services.AddDbContext<ApplicationSettingsDbContext>(options =>
+            options.UseSqlServer(connectionString));
+
+        // Add shared dependencies and service
+        return services.AddApplicationSettingsCore<ApplicationSettingsService>();
+    }
+
+    // Now place the different method after all AddApplicationSettings overloads
+    /// <summary>
+    /// Adds ApplicationSettings service using an existing DbContext
+    /// </summary>
+    /// <typeparam name="TContext">The existing DbContext type</typeparam>
+    /// <param name="services">Service collection</param>
+    /// <param name="configuration">Configuration</param>
+    /// <param name="schema">Optional schema override</param>
+    /// <returns>Service collection</returns>
+    public static IServiceCollection AddApplicationSettingsWithExistingContext<TContext>(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string? schema = null)
+        where TContext : DbContext
+    {
+        // Configure options using shared method
+        services.ConfigureApplicationSettingsOptions(configuration, schema);
+
+        // Add shared dependencies and service
+        return services.AddApplicationSettingsCore<ExistingContextApplicationSettingsService<TContext>>();
+    }
+
+    // All private helper methods remain the same...
+    /// <summary>
+    /// Configures ApplicationSettingsOptions with defaults and reads from configuration
+    /// </summary>
+    /// <param name="services">Service collection</param>
+    /// <param name="configuration">Configuration</param>
+    /// <param name="schema">Optional schema override</param>
+    private static void ConfigureApplicationSettingsOptions(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string? schema = null)
+    {
+        services.Configure<ApplicationSettingsOptions>(options =>
+        {
+            // Set defaults
+            SetDefaultOptions(options, schema);
+
+            // Read from configuration section if it exists
+            var section = configuration.GetSection(ApplicationSettingsOptions.ConfigurationSection);
+            if (section.Exists())
+            {
+                ApplyConfigurationSettings(options, section, schema);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Sets default values for ApplicationSettingsOptions
+    /// </summary>
+    /// <param name="options">Options to configure</param>
+    /// <param name="schema">Optional schema override</param>
+    private static void SetDefaultOptions(ApplicationSettingsOptions options, string? schema = null)
+    {
+        options.EnableCaching = true;
+        options.CacheExpirationMinutes = 30;
+        options.DefaultCategory = "General";
+        options.Schema = schema;
+    }
+
+    /// <summary>
+    /// Applies configuration settings from IConfiguration section
+    /// </summary>
+    /// <param name="options">Options to configure</param>
+    /// <param name="section">Configuration section</param>
+    /// <param name="schema">Optional schema override</param>
+    private static void ApplyConfigurationSettings(
+        ApplicationSettingsOptions options,
+        IConfiguration section,
+        string? schema = null)
+    {
+        if (bool.TryParse(section["EnableCaching"], out bool enableCaching))
+            options.EnableCaching = enableCaching;
+
+        if (int.TryParse(section["CacheExpirationMinutes"], out int cacheExpiration))
+            options.CacheExpirationMinutes = cacheExpiration;
+
+        if (!string.IsNullOrEmpty(section["DefaultCategory"]))
+            options.DefaultCategory = section["DefaultCategory"] ?? string.Empty;
+
+        // Schema from configuration (only if not overridden by parameter)
+        if (schema == null && !string.IsNullOrEmpty(section["Schema"]))
+            options.Schema = section["Schema"];
+    }
+
+    /// <summary>
+    /// Adds core dependencies and service registration
+    /// </summary>
+    /// <typeparam name="TService">Service implementation type</typeparam>
+    /// <param name="services">Service collection</param>
+    /// <returns>Service collection</returns>
+    private static IServiceCollection AddApplicationSettingsCore<TService>(this IServiceCollection services)
+        where TService : class, IApplicationSettingsService
+    {
+        // Add memory cache if not already added
+        services.AddMemoryCache();
+
+        // Add the service
+        services.AddScoped<IApplicationSettingsService, TService>();
+
+        return services;
+    }
+}

--- a/src/GovUK.Dfe.CoreLibs.ApplicationSettings/GovUK.Dfe.CoreLibs.ApplicationSettings.csproj
+++ b/src/GovUK.Dfe.CoreLibs.ApplicationSettings/GovUK.Dfe.CoreLibs.ApplicationSettings.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>GovUK.Dfe.CoreLibs.ApplicationSettings</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Department for Education</Authors>
+    <Description>Generic database-based application settings management library for DfE applications</Description>
+    <PackageTags>DfE;Settings;Database;Configuration;Generic</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/src/GovUK.Dfe.CoreLibs.ApplicationSettings/GovUK.Dfe.CoreLibs.ApplicationSettings.csproj
+++ b/src/GovUK.Dfe.CoreLibs.ApplicationSettings/GovUK.Dfe.CoreLibs.ApplicationSettings.csproj
@@ -10,8 +10,13 @@
     <Authors>Department for Education</Authors>
     <Description>Generic database-based application settings management library for DfE applications</Description>
     <PackageTags>DfE;Settings;Database;Configuration;Generic</PackageTags>
+	<PackageReadmeFile>readme.md</PackageReadmeFile>
   </PropertyGroup>
 
+	<ItemGroup>
+		<None Include="readme.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
+	
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
@@ -21,5 +26,10 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
   </ItemGroup>
+	<ItemGroup>
+		<None Update="readme.md">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/src/GovUK.Dfe.CoreLibs.ApplicationSettings/Interfaces/IApplicationSettingsService.cs
+++ b/src/GovUK.Dfe.CoreLibs.ApplicationSettings/Interfaces/IApplicationSettingsService.cs
@@ -1,0 +1,54 @@
+namespace GovUK.Dfe.CoreLibs.ApplicationSettings.Interfaces;
+
+public interface IApplicationSettingsService
+{
+    /// <summary>
+    /// Get a setting value by key
+    /// </summary>
+    Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get a strongly-typed setting value by key
+    /// </summary>
+    Task<T?> GetSettingAsync<T>(string key, CancellationToken cancellationToken = default) where T : class;
+
+    /// <summary>
+    /// Get a setting value by key with a default value if not found
+    /// </summary>
+    Task<string> GetSettingAsync(string key, string defaultValue, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get all settings for a specific category
+    /// </summary>
+    Task<Dictionary<string, string>> GetSettingsByCategoryAsync(string category, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get all active settings
+    /// </summary>
+    Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Set a setting value
+    /// </summary>
+    Task SetSettingAsync(string key, string value, string? description = null, string? category = null, string? updatedBy = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Set multiple settings at once
+    /// </summary>
+    Task SetSettingsAsync(Dictionary<string, string> settings, string? category = null, string? updatedBy = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Delete a setting (soft delete - sets IsActive to false)
+    /// </summary>
+    Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Check if a setting exists and is active
+    /// </summary>
+    Task<bool> SettingExistsAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Refresh cached settings
+    /// </summary>
+    Task RefreshCacheAsync(CancellationToken cancellationToken = default);
+}

--- a/src/GovUK.Dfe.CoreLibs.ApplicationSettings/Services/ApplicationSettingsService.cs
+++ b/src/GovUK.Dfe.CoreLibs.ApplicationSettings/Services/ApplicationSettingsService.cs
@@ -1,0 +1,34 @@
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Configuration;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Data;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace GovUK.Dfe.CoreLibs.ApplicationSettings.Services;
+
+public class ApplicationSettingsService : BaseApplicationSettingsService
+{
+    private readonly ApplicationSettingsDbContext _context;
+
+    public ApplicationSettingsService(
+        ApplicationSettingsDbContext context,
+        IMemoryCache cache,
+        IOptions<ApplicationSettingsOptions> options,
+        ILogger<ApplicationSettingsService> logger)
+        : base(cache, options, logger)
+    {
+        _context = context;
+    }
+
+    protected override DbSet<ApplicationSetting> GetApplicationSettingsDbSet()
+    {
+        return _context.ApplicationSettings;
+    }
+
+    protected override async Task SaveChangesAsync(CancellationToken cancellationToken)
+    {
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/GovUK.Dfe.CoreLibs.ApplicationSettings/Services/BaseApplicationSettingsService.cs
+++ b/src/GovUK.Dfe.CoreLibs.ApplicationSettings/Services/BaseApplicationSettingsService.cs
@@ -1,0 +1,282 @@
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Configuration;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Entities;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Text.Json;
+
+namespace GovUK.Dfe.CoreLibs.ApplicationSettings.Services;
+
+public abstract class BaseApplicationSettingsService : IApplicationSettingsService
+{
+    protected readonly IMemoryCache _cache;
+    protected readonly ApplicationSettingsOptions _options;
+    protected readonly ILogger _logger;
+
+    protected const string CacheKeyPrefix = "AppSettings_";
+    protected const string AllSettingsCacheKey = "AppSettings_All";
+
+    protected BaseApplicationSettingsService(
+        IMemoryCache cache,
+        IOptions<ApplicationSettingsOptions> options,
+        ILogger logger)
+    {
+        _cache = cache;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    protected abstract DbSet<ApplicationSetting> GetApplicationSettingsDbSet();
+    protected abstract Task SaveChangesAsync(CancellationToken cancellationToken);
+
+    public async Task<string?> GetSettingAsync(string key, CancellationToken cancellationToken = default)
+    {
+        ValidateKey(key);
+
+        var cacheKey = BuildCacheKey(key);
+        if (TryGetCachedValue(cacheKey, out string? cachedValue))
+        {
+            return cachedValue;
+        }
+
+        var setting = await GetApplicationSettingsDbSet()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.Key == key && s.IsActive, cancellationToken);
+
+        var value = setting?.Value;
+        CacheValueIfEnabled(cacheKey, value);
+
+        return value;
+    }
+
+    public async Task<T?> GetSettingAsync<T>(string key, CancellationToken cancellationToken = default) where T : class
+    {
+        var value = await GetSettingAsync(key, cancellationToken);
+        if (value == null) return null;
+
+        return DeserializeValue<T>(value, key);
+    }
+
+    public async Task<string> GetSettingAsync(string key, string defaultValue, CancellationToken cancellationToken = default)
+    {
+        var value = await GetSettingAsync(key, cancellationToken);
+        return value ?? defaultValue;
+    }
+
+    public async Task<Dictionary<string, string>> GetSettingsByCategoryAsync(string category, CancellationToken cancellationToken = default)
+    {
+        ValidateCategory(category);
+
+        var cacheKey = BuildCategoryCacheKey(category);
+        if (TryGetCachedValue(cacheKey, out Dictionary<string, string>? cachedSettings))
+        {
+            return cachedSettings!;
+        }
+
+        var settings = await GetApplicationSettingsDbSet()
+            .AsNoTracking()
+            .Where(s => s.Category == category && s.IsActive)
+            .ToDictionaryAsync(s => s.Key, s => s.Value, cancellationToken);
+
+        CacheValueIfEnabled(cacheKey, settings);
+        return settings;
+    }
+
+    public async Task<Dictionary<string, string>> GetAllSettingsAsync(CancellationToken cancellationToken = default)
+    {
+        if (TryGetCachedValue(AllSettingsCacheKey, out Dictionary<string, string>? cachedAllSettings))
+        {
+            return cachedAllSettings!;
+        }
+
+        var settings = await GetApplicationSettingsDbSet()
+            .AsNoTracking()
+            .Where(s => s.IsActive)
+            .ToDictionaryAsync(s => s.Key, s => s.Value, cancellationToken);
+
+        CacheValueIfEnabled(AllSettingsCacheKey, settings);
+        return settings;
+    }
+
+    public async Task SetSettingAsync(string key, string value, string? description = null, string? category = null, string? updatedBy = null, CancellationToken cancellationToken = default)
+    {
+        ValidateKey(key);
+        ValidateValue(value);
+
+        var setting = await GetApplicationSettingsDbSet()
+            .FirstOrDefaultAsync(s => s.Key == key, cancellationToken);
+
+        var effectiveCategory = category ?? _options.DefaultCategory;
+
+        if (setting == null)
+        {
+            setting = CreateNewSetting(key, value, description, effectiveCategory, updatedBy);
+            GetApplicationSettingsDbSet().Add(setting);
+        }
+        else
+        {
+            UpdateExistingSetting(setting, value, description, effectiveCategory, updatedBy);
+        }
+
+        await SaveChangesAsync(cancellationToken);
+        InvalidateRelatedCache(key, effectiveCategory);
+        LogSettingUpdate(key, updatedBy);
+    }
+
+    public async Task SetSettingsAsync(Dictionary<string, string> settings, string? category = null, string? updatedBy = null, CancellationToken cancellationToken = default)
+    {
+        if (settings == null || settings.Count == 0) return;
+
+        foreach (var kvp in settings)
+        {
+            await SetSettingAsync(kvp.Key, kvp.Value, null, category, updatedBy, cancellationToken);
+        }
+    }
+
+    public async Task DeleteSettingAsync(string key, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(key)) return;
+
+        var setting = await GetApplicationSettingsDbSet()
+            .FirstOrDefaultAsync(s => s.Key == key, cancellationToken);
+
+        if (setting != null)
+        {
+            setting.IsActive = false;
+            setting.UpdatedAt = DateTime.UtcNow;
+            await SaveChangesAsync(cancellationToken);
+
+            InvalidateRelatedCache(key, setting.Category);
+            _logger.LogInformation("Setting {Key} deleted", key);
+        }
+    }
+
+    public async Task<bool> SettingExistsAsync(string key, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(key)) return false;
+
+        return await GetApplicationSettingsDbSet()
+            .AnyAsync(s => s.Key == key && s.IsActive, cancellationToken);
+    }
+
+    public async Task RefreshCacheAsync(CancellationToken cancellationToken = default)
+    {
+        if (!_options.EnableCaching) return;
+
+        var allSettings = await GetApplicationSettingsDbSet()
+            .Where(s => s.IsActive)
+            .ToListAsync(cancellationToken);
+
+        foreach (var setting in allSettings)
+        {
+            var cacheKey = BuildCacheKey(setting.Key);
+            CacheValueIfEnabled(cacheKey, setting.Value);
+        }
+
+        _logger.LogInformation("Application settings cache refreshed with {Count} settings", allSettings.Count);
+    }
+
+    #region Helper Methods
+
+    protected static string BuildCacheKey(string key) => $"{CacheKeyPrefix}{key}";
+    protected static string BuildCategoryCacheKey(string category) => $"{CacheKeyPrefix}Category_{category}";
+
+    protected bool TryGetCachedValue<T>(string cacheKey, out T? cachedValue) where T : class
+    {
+        cachedValue = default;
+        return _options.EnableCaching && _cache.TryGetValue(cacheKey, out cachedValue);
+    }
+
+    protected void CacheValueIfEnabled<T>(string cacheKey, T? value) where T : class
+    {
+        if (_options.EnableCaching && value != null)
+        {
+            var cacheOptions = CreateCacheOptions();
+            _cache.Set(cacheKey, value, cacheOptions);
+        }
+    }
+
+    protected MemoryCacheEntryOptions CreateCacheOptions()
+    {
+        return new MemoryCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(_options.CacheExpirationMinutes)
+        };
+    }
+
+    protected void InvalidateRelatedCache(string key, string category)
+    {
+        if (_options.EnableCaching)
+        {
+            _cache.Remove(BuildCacheKey(key));
+            _cache.Remove(BuildCategoryCacheKey(category));
+            _cache.Remove(AllSettingsCacheKey);
+        }
+    }
+
+    protected T? DeserializeValue<T>(string value, string key) where T : class
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<T>(value);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError(ex, "Failed to deserialize setting {Key} to type {Type}", key, typeof(T).Name);
+            return null;
+        }
+    }
+
+    protected static ApplicationSetting CreateNewSetting(string key, string value, string? description, string category, string? updatedBy)
+    {
+        return new ApplicationSetting
+        {
+            Key = key,
+            Value = value,
+            Description = description,
+            Category = category,
+            CreatedBy = updatedBy,
+            UpdatedBy = updatedBy
+        };
+    }
+
+    protected static void UpdateExistingSetting(ApplicationSetting setting, string value, string? description, string category, string? updatedBy)
+    {
+        setting.Value = value;
+        setting.Description = description ?? setting.Description;
+        setting.Category = category ?? setting.Category;
+        setting.UpdatedAt = DateTime.UtcNow;
+        setting.UpdatedBy = updatedBy;
+        setting.IsActive = true;
+    }
+
+    protected void LogSettingUpdate(string key, string? updatedBy)
+    {
+        _logger.LogInformation("Setting {Key} updated by {UpdatedBy}", key, updatedBy ?? "System");
+    }
+
+    #endregion
+
+    #region Validation Methods
+
+    protected static void ValidateKey(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Setting key cannot be null or empty", nameof(key));
+    }
+
+    protected static void ValidateValue(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+    }
+
+    protected static void ValidateCategory(string category)
+    {
+        if (string.IsNullOrWhiteSpace(category))
+            throw new ArgumentException("Category cannot be null or empty", nameof(category));
+    }
+
+    #endregion
+}

--- a/src/GovUK.Dfe.CoreLibs.ApplicationSettings/Services/ExistingContextApplicationSettingsService.cs
+++ b/src/GovUK.Dfe.CoreLibs.ApplicationSettings/Services/ExistingContextApplicationSettingsService.cs
@@ -1,0 +1,34 @@
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Configuration;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace GovUK.Dfe.CoreLibs.ApplicationSettings.Services;
+
+public class ExistingContextApplicationSettingsService<TContext> : BaseApplicationSettingsService
+    where TContext : DbContext
+{
+    private readonly TContext _context;
+
+    public ExistingContextApplicationSettingsService(
+        TContext context,
+        IMemoryCache cache,
+        IOptions<ApplicationSettingsOptions> options,
+        ILogger<ExistingContextApplicationSettingsService<TContext>> logger)
+        : base(cache, options, logger)
+    {
+        _context = context;
+    }
+
+    protected override DbSet<ApplicationSetting> GetApplicationSettingsDbSet()
+    {
+        return _context.Set<ApplicationSetting>();
+    }
+
+    protected override async Task SaveChangesAsync(CancellationToken cancellationToken)
+    {
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/GovUK.Dfe.CoreLibs.ApplicationSettings/readme.md
+++ b/src/GovUK.Dfe.CoreLibs.ApplicationSettings/readme.md
@@ -1,0 +1,134 @@
+# GovUK.Dfe.CoreLibs.ApplicationSettings
+
+A generic, database-backed application settings management library for DfE applications. This package provides a consistent way to manage, retrieve, and update application settings using Entity Framework Core and integrates with .NET configuration and dependency injection.
+
+## Features
+
+- Store and retrieve application settings from a database
+- Integrates with Microsoft.Extensions.Configuration and Microsoft.Extensions.Options
+- Supports caching for improved performance
+- Designed for use with .NET 8 and Entity Framework Core
+
+## Installation
+
+Add the NuGet package to your project:
+
+```shell
+dotnet add package GovUK.Dfe.CoreLibs.ApplicationSettings
+```
+
+Or via Visual Studio NuGet Package Manager.
+
+## Integration Guide
+
+Follow these steps to integrate the package with your existing application:
+
+### 1. Add the ApplicationSetting Entity to Your DbContext
+
+Add a `DbSet<ApplicationSetting>` property to your `DbContext`:
+
+```csharp
+public class AppSettingsDbContext : DbContext
+{
+    public DbSet<ApplicationSetting> ApplicationSettings { get; set; }
+    // ...
+}
+```
+
+### Using ApplicationSettings with an Existing DbContext
+
+You do not need to create a dedicated `DbContext` for application settings.
+If you have an existing `DbContext`, simply add a `DbSet<ApplicationSetting>` property and call the `ConfigureApplicationSettings` extension method in your `OnModelCreating` override:
+
+```csharp
+public class MyAppDbContext : DbContext
+{
+    public DbSet<ApplicationSetting> ApplicationSettings { get; set; }
+    // ... your other DbSets
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        // Configure ApplicationSetting entity for use in your existing context
+        modelBuilder.ConfigureApplicationSettings(schema: "dbo", tableName: "ApplicationSettings");
+        base.OnModelCreating(modelBuilder);
+    }
+}
+```
+
+This ensures the `ApplicationSetting` entity is mapped and configured correctly alongside your other entities.
+
+### 2. Configure the ApplicationSetting Entity
+
+In your `DbContext`, override `OnModelCreating` and use the provided extension method to configure the entity:
+
+```csharp
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+{
+    // Configure ApplicationSetting entity with optional schema and table name
+    modelBuilder.ConfigureApplicationSettings(schema: "dbo", tableName: "ApplicationSettings");
+    base.OnModelCreating(modelBuilder);
+}
+```
+
+Or, if you are using options from DI:
+
+```csharp
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+{
+    modelBuilder.ConfigureApplicationSettings(options);
+    base.OnModelCreating(modelBuilder);
+}
+```
+
+#### About the Extension Methods
+
+The package provides two extension methods for configuring the `ApplicationSetting` entity:
+
+- `ConfigureApplicationSettings(this ModelBuilder modelBuilder, string? schema = null, string tableName = "ApplicationSettings")`  
+  Configures the entity with the specified schema and table name, setting up keys, indexes, and property constraints.
+
+- `ConfigureApplicationSettings(this ModelBuilder modelBuilder, ApplicationSettingsOptions options)`  
+  Configures the entity using options (such as schema) provided via dependency injection.
+
+These methods ensure your database table is correctly structured for storing application settings.
+
+### 3. Register Services in Dependency Injection
+
+In your `Program.cs` or `Startup.cs`:
+
+```csharp
+services.AddDbContext<AppSettingsDbContext>(options =>
+    options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection")));
+
+services.AddApplicationSettings<AppSettingsDbContext>();
+```
+
+### 4. Apply Migrations
+
+Generate and apply EF Core migrations to create the `ApplicationSettings` table:
+
+```shell
+dotnet ef migrations add AddApplicationSettings
+dotnet ef database update
+```
+
+### 5. Access Settings in Your Code
+
+Inject `IApplicationSettings` where needed:
+
+```csharp
+public class MyService
+{
+    private readonly IApplicationSettings _settings;
+
+    public MyService(IApplicationSettings settings)
+    {
+        _settings = settings;
+    }
+
+    public async Task<string> GetSettingAsync()
+    {
+        return await _settings.GetAsync<string>("MySettingKey");
+    }
+}
+```

--- a/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/ApplicationSettingTests.cs
+++ b/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/ApplicationSettingTests.cs
@@ -1,0 +1,52 @@
+﻿using FluentAssertions;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Entities;
+
+namespace GovUK.Dfe.CoreLibs.ApplicationSettings.Tests.Entities;
+
+public class ApplicationSettingTests
+{
+    [Fact]
+    public void ApplicationSetting_ShouldInitializeWithDefaultValues()
+    {
+        // Act
+        var setting = new ApplicationSetting();
+
+        // Assert
+        setting.Key.Should().Be(string.Empty);
+        setting.Value.Should().Be(string.Empty);
+        setting.Category.Should().Be("General");
+        setting.IsActive.Should().BeTrue();
+        setting.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        setting.UpdatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public void ApplicationSetting_ShouldAllowSettingProperties()
+    {
+        // Arrange
+        var key = "TestKey";
+        var value = "TestValue";
+        var description = "Test Description";
+        var category = "TestCategory";
+        var createdBy = "TestUser";
+
+        // Act
+        var setting = new ApplicationSetting
+        {
+            Key = key,
+            Value = value,
+            Description = description,
+            Category = category,
+            CreatedBy = createdBy,
+            IsActive = false
+        };
+
+        // Assert
+        setting.Key.Should().Be(key);
+        setting.Value.Should().Be(value);
+        setting.Description.Should().Be(description);
+        setting.Category.Should().Be(category);
+        setting.CreatedBy.Should().Be(createdBy);
+        setting.IsActive.Should().BeFalse();
+    }
+}

--- a/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/ApplicationSettingsDbContextTests.cs
+++ b/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/ApplicationSettingsDbContextTests.cs
@@ -1,0 +1,80 @@
+﻿using FluentAssertions;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Data;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Entities;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Tests.TestHelpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUK.Dfe.CoreLibs.ApplicationSettings.Tests.Data;
+
+public class ApplicationSettingsDbContextTests : IDisposable
+{
+    private readonly ApplicationSettingsDbContext _context;
+
+    public ApplicationSettingsDbContextTests()
+    {
+        _context = TestDbContextFactory.CreateInMemoryContext();
+    }
+
+    [Fact]
+    public void DbContext_ShouldHaveApplicationSettingsDbSet()
+    {
+        // Assert
+        _context.ApplicationSettings.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task DbContext_ShouldAllowAddingAndRetrievingSettings()
+    {
+        // Arrange
+        var setting = TestData.CreateSetting();
+
+        // Act
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        var retrievedSetting = await _context.ApplicationSettings
+            .FirstOrDefaultAsync(s => s.Key == setting.Key);
+
+        // Assert
+        retrievedSetting.Should().NotBeNull();
+        retrievedSetting!.Key.Should().Be(setting.Key);
+        retrievedSetting.Value.Should().Be(setting.Value);
+    }
+
+    [Fact]
+    public void DbContext_ShouldConfigureUniqueIndexOnKey()
+    {
+        // Arrange & Act
+        var entityType = _context.Model.FindEntityType(typeof(ApplicationSetting));
+
+        // Assert
+        entityType.Should().NotBeNull();
+
+        var keyIndex = entityType!.GetIndexes()
+            .FirstOrDefault(i => i.Properties.Any(p => p.Name == nameof(ApplicationSetting.Key)));
+
+        keyIndex.Should().NotBeNull();
+        keyIndex!.IsUnique.Should().BeTrue();
+        keyIndex.GetDatabaseName().Should().Be("IX_ApplicationSettings_Key");
+    }
+
+    [Fact]
+    public void DbContext_ShouldConfigureWithCustomSchema()
+    {
+        // Arrange
+        var customSchema = "CustomSchema";
+
+        // Act
+        using var contextWithSchema = TestDbContextFactory.CreateInMemoryContext(customSchema);
+
+        // Assert
+        contextWithSchema.Should().NotBeNull();
+        // Note: Schema testing is limited in InMemory provider, but we can verify context creation
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/ApplicationSettingsOptionsTests.cs
+++ b/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/ApplicationSettingsOptionsTests.cs
@@ -1,0 +1,47 @@
+﻿using FluentAssertions;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Configuration;
+
+namespace GovUK.Dfe.CoreLibs.ApplicationSettings.Tests.Configuration;
+
+public class ApplicationSettingsOptionsTests
+{
+    [Fact]
+    public void ApplicationSettingsOptions_ShouldHaveCorrectDefaultValues()
+    {
+        // Act
+        var options = new ApplicationSettingsOptions();
+
+        // Assert
+        options.Schema.Should().BeNull();
+        options.EnableCaching.Should().BeTrue();
+        options.CacheExpirationMinutes.Should().Be(30);
+        options.DefaultCategory.Should().Be("General");
+    }
+
+    [Fact]
+    public void ApplicationSettingsOptions_ShouldAllowPropertyOverrides()
+    {
+        // Act
+        var options = new ApplicationSettingsOptions
+        {
+            Schema = "CustomSchema",
+            EnableCaching = false,
+            CacheExpirationMinutes = 60,
+            DefaultCategory = "Custom"
+        };
+
+        // Assert
+        options.Schema.Should().Be("CustomSchema");
+        options.EnableCaching.Should().BeFalse();
+        options.CacheExpirationMinutes.Should().Be(60);
+        options.DefaultCategory.Should().Be("Custom");
+
+    }
+
+    [Fact]
+    public void ApplicationSettingsOptions_ConfigurationSection_ShouldBeCorrect()
+    {
+        // Assert
+        ApplicationSettingsOptions.ConfigurationSection.Should().Be("ApplicationSettings");
+    }
+}

--- a/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/ApplicationSettingsServiceTests.cs
+++ b/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/ApplicationSettingsServiceTests.cs
@@ -1,0 +1,344 @@
+﻿using FluentAssertions;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Configuration;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Data;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Services;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Tests.TestHelpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Text.Json;
+
+namespace GovUK.Dfe.CoreLibs.ApplicationSettings.Tests.Services;
+
+public class ApplicationSettingsServiceTests : IDisposable
+{
+    private readonly ApplicationSettingsDbContext _context;
+    private readonly MemoryCache _cache;
+    private readonly Mock<ILogger<ApplicationSettingsService>> _mockLogger;
+    private readonly ApplicationSettingsOptions _options;
+    private readonly ApplicationSettingsService _service;
+
+    public ApplicationSettingsServiceTests()
+    {
+        _context = TestDbContextFactory.CreateInMemoryContext();
+        _cache = new MemoryCache(new MemoryCacheOptions());
+        _mockLogger = new Mock<ILogger<ApplicationSettingsService>>();
+        _options = new ApplicationSettingsOptions();
+
+        _service = new ApplicationSettingsService(
+            _context,
+            _cache,
+            Options.Create(_options),
+            _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task GetSettingAsync_WithValidKey_ShouldReturnValue()
+    {
+        // Arrange
+        var setting = TestData.CreateSetting("TestKey", "TestValue");
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _service.GetSettingAsync("TestKey");
+
+        // Assert
+        result.Should().Be("TestValue");
+    }
+
+    [Fact]
+    public async Task GetSettingAsync_WithInvalidKey_ShouldReturnNull()
+    {
+        // Act
+        var result = await _service.GetSettingAsync("NonExistentKey");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetSettingAsync_WithNullOrEmptyKey_ShouldThrowArgumentException()
+    {
+        // Act & Assert
+        var act1 = async () => await _service.GetSettingAsync(null!);
+        var act2 = async () => await _service.GetSettingAsync("");
+        var act3 = async () => await _service.GetSettingAsync("   ");
+
+        await act1.Should().ThrowAsync<ArgumentException>();
+        await act2.Should().ThrowAsync<ArgumentException>();
+        await act3.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task GetSettingAsync_WithInactiveSetting_ShouldReturnNull()
+    {
+        // Arrange
+        var setting = TestData.CreateSetting("InactiveKey", "InactiveValue", isActive: false);
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _service.GetSettingAsync("InactiveKey");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetSettingAsync_Generic_WithValidJson_ShouldReturnDeserialized()
+    {
+        // Arrange
+        var testObject = new { Name = "Test", Value = 123 };
+        var jsonValue = JsonSerializer.Serialize(testObject);
+        var setting = TestData.CreateSetting("JsonKey", jsonValue);
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // Act - Use object instead of dynamic
+        var result = await _service.GetSettingAsync<object>("JsonKey");
+
+        // Assert
+        result.Should().NotBeNull();
+        // You can also cast to JsonElement to access properties
+        if (result != null) // Consider adding this defensive check
+        {
+            var jsonElement = (JsonElement)result;
+            jsonElement.GetProperty("Name").GetString().Should().Be("Test");
+            jsonElement.GetProperty("Value").GetInt32().Should().Be(123);
+        }
+    }
+
+    [Fact]
+    public async Task GetSettingAsync_WithDefaultValue_ShouldReturnDefaultWhenNotFound()
+    {
+        // Act
+        var result = await _service.GetSettingAsync("NonExistentKey", "DefaultValue");
+
+        // Assert
+        result.Should().Be("DefaultValue");
+    }
+
+    [Fact]
+    public async Task GetSettingsByCategoryAsync_ShouldReturnOnlyActiveSettingsInCategory()
+    {
+        // Arrange
+        var settings = new[]
+        {
+            TestData.CreateSetting("Key1", "Value1", "TestCategory"),
+            TestData.CreateSetting("Key2", "Value2", "TestCategory"),
+            TestData.CreateSetting("Key3", "Value3", "OtherCategory"),
+            TestData.CreateSetting("Key4", "Value4", "TestCategory", isActive: false)
+        };
+
+        _context.ApplicationSettings.AddRange(settings);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _service.GetSettingsByCategoryAsync("TestCategory");
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().ContainKeys("Key1", "Key2");
+        result.Should().NotContainKeys("Key3", "Key4");
+    }
+
+    [Fact]
+    public async Task GetAllSettingsAsync_ShouldReturnOnlyActiveSettings()
+    {
+        // Arrange
+        var settings = new[]
+        {
+            TestData.CreateSetting("Key1", "Value1"),
+            TestData.CreateSetting("Key2", "Value2"),
+            TestData.CreateSetting("Key3", "Value3", isActive: false)
+        };
+
+        _context.ApplicationSettings.AddRange(settings);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _service.GetAllSettingsAsync();
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().ContainKeys("Key1", "Key2");
+        result.Should().NotContainKey("Key3");
+    }
+
+    [Fact]
+    public async Task SetSettingAsync_WithNewSetting_ShouldCreateSetting()
+    {
+        // Act
+        await _service.SetSettingAsync("NewKey", "NewValue", "Description", "Category", "User");
+
+        // Assert
+        var setting = await _context.ApplicationSettings
+            .FirstOrDefaultAsync(s => s.Key == "NewKey");
+
+        setting.Should().NotBeNull();
+        setting!.Value.Should().Be("NewValue");
+        setting.Description.Should().Be("Description");
+        setting.Category.Should().Be("Category");
+        setting.CreatedBy.Should().Be("User");
+        setting.UpdatedBy.Should().Be("User");
+    }
+
+    [Fact]
+    public async Task SetSettingAsync_WithExistingSetting_ShouldUpdateSetting()
+    {
+        // Arrange
+        var existingSetting = TestData.CreateSetting("ExistingKey", "OldValue");
+        _context.ApplicationSettings.Add(existingSetting);
+        await _context.SaveChangesAsync();
+
+        // Act
+        await _service.SetSettingAsync("ExistingKey", "NewValue", "Updated Description", "Updated Category", "UpdateUser");
+
+        // Assert
+        var setting = await _context.ApplicationSettings
+            .FirstOrDefaultAsync(s => s.Key == "ExistingKey");
+
+        setting.Should().NotBeNull();
+        setting!.Value.Should().Be("NewValue");
+        setting.Description.Should().Be("Updated Description");
+        setting.Category.Should().Be("Updated Category");
+        setting.UpdatedBy.Should().Be("UpdateUser");
+    }
+
+    [Fact]
+    public async Task SetSettingAsync_WithNullValue_ShouldThrowArgumentNullException()
+    {
+        // Act & Assert
+        var act = async () => await _service.SetSettingAsync("TestKey", null!);
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task SetSettingsAsync_WithMultipleSettings_ShouldCreateAll()
+    {
+        // Arrange
+        var settings = new Dictionary<string, string>
+        {
+            { "Key1", "Value1" },
+            { "Key2", "Value2" },
+            { "Key3", "Value3" }
+        };
+
+        // Act
+        await _service.SetSettingsAsync(settings, "BatchCategory", "BatchUser");
+
+        // Assert
+        var savedSettings = await _context.ApplicationSettings.ToListAsync();
+        savedSettings.Should().HaveCount(3);
+        savedSettings.Should().AllSatisfy(s => s.Category.Should().Be("BatchCategory"));
+    }
+
+    [Fact]
+    public async Task DeleteSettingAsync_ShouldSetIsActiveToFalse()
+    {
+        // Arrange
+        var setting = TestData.CreateSetting("DeleteKey", "DeleteValue");
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // Act
+        await _service.DeleteSettingAsync("DeleteKey");
+
+        // Assert
+        var deletedSetting = await _context.ApplicationSettings
+            .FirstOrDefaultAsync(s => s.Key == "DeleteKey");
+
+        deletedSetting.Should().NotBeNull();
+        deletedSetting!.IsActive.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SettingExistsAsync_WithExistingActiveSetting_ShouldReturnTrue()
+    {
+        // Arrange
+        var setting = TestData.CreateSetting("ExistsKey", "ExistsValue");
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _service.SettingExistsAsync("ExistsKey");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SettingExistsAsync_WithInactiveSetting_ShouldReturnFalse()
+    {
+        // Arrange
+        var setting = TestData.CreateSetting("InactiveKey", "InactiveValue", isActive: false);
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _service.SettingExistsAsync("InactiveKey");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SettingExistsAsync_WithNonExistentKey_ShouldReturnFalse()
+    {
+        // Act
+        var result = await _service.SettingExistsAsync("NonExistentKey");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RefreshCacheAsync_ShouldCacheAllActiveSettings()
+    {
+        // Arrange
+        var settings = TestData.CreateMultipleSettings();
+        _context.ApplicationSettings.AddRange(settings);
+        await _context.SaveChangesAsync();
+
+        // Act
+        await _service.RefreshCacheAsync();
+
+        // Assert - We can't directly verify cache contents, but we can verify no exceptions
+        // and that subsequent calls use cache
+        var result = await _service.GetSettingAsync("Setting1");
+        result.Should().Be("Value1");
+    }
+
+    [Fact]
+    public async Task GetSettingAsync_WithCachingEnabled_ShouldUseCacheOnSubsequentCalls()
+    {
+        // Arrange
+        var setting = TestData.CreateSetting("CachedKey", "CachedValue");
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // Act - First call should hit database
+        var result1 = await _service.GetSettingAsync("CachedKey");
+
+        // Modify database value
+        setting.Value = "ModifiedValue";
+        await _context.SaveChangesAsync();
+
+        // Second call should return cached value
+        var result2 = await _service.GetSettingAsync("CachedKey");
+
+        // Assert
+        result1.Should().Be("CachedValue");
+        result2.Should().Be("CachedValue"); // Should be cached, not "ModifiedValue"
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _cache.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/DbContextExtensionsTests.cs
+++ b/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/DbContextExtensionsTests.cs
@@ -1,0 +1,95 @@
+﻿using FluentAssertions;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Configuration;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Entities;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Extensions;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUK.Dfe.CoreLibs.ApplicationSettings.Tests.Extensions;
+
+public class DbContextExtensionsTests
+{
+    [Fact]
+    public void ConfigureApplicationSettings_WithDefaultParameters_ShouldConfigureEntity()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        // Act & Assert - Should not throw
+        using var context = new TestDbContext(options);
+        var entityType = context.Model.FindEntityType(typeof(ApplicationSetting));
+
+        entityType.Should().NotBeNull();
+        entityType!.GetTableName().Should().Be("ApplicationSettings");
+    }
+
+    [Fact]
+    public void ConfigureApplicationSettings_WithCustomSchemaAndTable_ShouldApplyConfiguration()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<TestDbContextWithSchema>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        // Act & Assert - Should not throw
+        using var context = new TestDbContextWithSchema(options);
+        var entityType = context.Model.FindEntityType(typeof(ApplicationSetting));
+
+        entityType.Should().NotBeNull();
+        entityType!.GetTableName().Should().Be("CustomTable");
+    }
+
+    [Fact]
+    public void ConfigureApplicationSettings_WithOptions_ShouldConfigureCorrectly()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<TestDbContextWithOptions>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        // Act & Assert - Should not throw
+        using var context = new TestDbContextWithOptions(options);
+        var entityType = context.Model.FindEntityType(typeof(ApplicationSetting));
+
+        entityType.Should().NotBeNull();
+    }
+
+    // Test DbContext classes
+    private class TestDbContext : DbContext
+    {
+        public TestDbContext(DbContextOptions<TestDbContext> options) : base(options) { }
+        public DbSet<ApplicationSetting> ApplicationSettings { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.ConfigureApplicationSettings();
+            base.OnModelCreating(modelBuilder);
+        }
+    }
+
+    private class TestDbContextWithSchema : DbContext
+    {
+        public TestDbContextWithSchema(DbContextOptions<TestDbContextWithSchema> options) : base(options) { }
+        public DbSet<ApplicationSetting> ApplicationSettings { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.ConfigureApplicationSettings("CustomSchema", "CustomTable");
+            base.OnModelCreating(modelBuilder);
+        }
+    }
+
+    private class TestDbContextWithOptions : DbContext
+    {
+        public TestDbContextWithOptions(DbContextOptions<TestDbContextWithOptions> options) : base(options) { }
+        public DbSet<ApplicationSetting> ApplicationSettings { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            var appOptions = new ApplicationSettingsOptions { Schema = "TestSchema" };
+            modelBuilder.ConfigureApplicationSettings(appOptions);
+            base.OnModelCreating(modelBuilder);
+        }
+    }
+}

--- a/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/ExistingContextApplicationSettingsServiceTests.cs
+++ b/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/ExistingContextApplicationSettingsServiceTests.cs
@@ -1,0 +1,714 @@
+﻿using FluentAssertions;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Configuration;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Entities;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Services;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Tests.TestHelpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Text.Json;
+
+namespace GovUK.Dfe.CoreLibs.ApplicationSettings.Tests.Services;
+
+public class ExistingContextApplicationSettingsServiceTests : IDisposable
+{
+    private readonly TestDbContext _context;
+    private readonly MemoryCache _cache;
+    private readonly Mock<ILogger<ExistingContextApplicationSettingsService<TestDbContext>>> _mockLogger;
+    private readonly ApplicationSettingsOptions _options;
+    private readonly ExistingContextApplicationSettingsService<TestDbContext> _service;
+
+    public ExistingContextApplicationSettingsServiceTests()
+    {
+        _context = CreateTestDbContext();
+        _cache = new MemoryCache(new MemoryCacheOptions());
+        _mockLogger = new Mock<ILogger<ExistingContextApplicationSettingsService<TestDbContext>>>();
+        _options = new ApplicationSettingsOptions
+        {
+            EnableCaching = true,
+            CacheExpirationMinutes = 30,
+            DefaultCategory = "General"
+        };
+
+        _service = new ExistingContextApplicationSettingsService<TestDbContext>(
+            _context,
+            _cache,
+            Options.Create(_options),
+            _mockLogger.Object);
+    }
+
+    #region GetSettingAsync Tests
+
+    [Fact]
+    public async Task GetSettingAsync_WithValidKey_ShouldReturnValue()
+    {
+        // Arrange
+        var setting = TestData.CreateSetting("TestKey", "TestValue");
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _service.GetSettingAsync("TestKey");
+
+        // Assert
+        result.Should().Be("TestValue");
+    }
+
+    [Fact]
+    public async Task GetSettingAsync_WithInvalidKey_ShouldReturnNull()
+    {
+        // Act
+        var result = await _service.GetSettingAsync("NonExistentKey");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetSettingAsync_WithNullOrEmptyKey_ShouldThrowArgumentException()
+    {
+        // Act & Assert
+        var act1 = async () => await _service.GetSettingAsync(null!);
+        var act2 = async () => await _service.GetSettingAsync("");
+        var act3 = async () => await _service.GetSettingAsync("   ");
+
+        await act1.Should().ThrowAsync<ArgumentException>().WithMessage("*Setting key cannot be null or empty*");
+        await act2.Should().ThrowAsync<ArgumentException>().WithMessage("*Setting key cannot be null or empty*");
+        await act3.Should().ThrowAsync<ArgumentException>().WithMessage("*Setting key cannot be null or empty*");
+    }
+
+    [Fact]
+    public async Task GetSettingAsync_WithInactiveSetting_ShouldReturnNull()
+    {
+        // Arrange
+        var setting = TestData.CreateSetting("InactiveKey", "InactiveValue", isActive: false);
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _service.GetSettingAsync("InactiveKey");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetSettingAsync_WithCachingEnabled_ShouldReturnCachedValue()
+    {
+        // Arrange
+        var setting = TestData.CreateSetting("CachedKey", "CachedValue");
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // First call to cache the value
+        await _service.GetSettingAsync("CachedKey");
+
+        // Remove from database
+        _context.ApplicationSettings.Remove(setting);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _service.GetSettingAsync("CachedKey");
+
+        // Assert
+        result.Should().Be("CachedValue");
+    }
+
+    [Fact]
+    public async Task GetSettingAsync_WithCachingDisabled_ShouldNotUseCache()
+    {
+        // Arrange
+        _options.EnableCaching = false;
+        var service = new ExistingContextApplicationSettingsService<TestDbContext>(
+            _context, _cache, Options.Create(_options), _mockLogger.Object);
+
+        var setting = TestData.CreateSetting("NoCacheKey", "NoCacheValue");
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // First call
+        await service.GetSettingAsync("NoCacheKey");
+
+        // Remove from database
+        _context.ApplicationSettings.Remove(setting);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await service.GetSettingAsync("NoCacheKey");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region GetSettingAsync Generic Tests
+
+    [Fact]
+    public async Task GetSettingAsync_Generic_WithValidJson_ShouldReturnDeserialized()
+    {
+        // Arrange
+        var testObject = new TestModel { Name = "Test", Value = 123 };
+        var jsonValue = JsonSerializer.Serialize(testObject);
+        var setting = TestData.CreateSetting("JsonKey", jsonValue);
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _service.GetSettingAsync<TestModel>("JsonKey");
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Test");
+        result.Value.Should().Be(123);
+    }
+
+    [Fact]
+    public async Task GetSettingAsync_Generic_WithInvalidJson_ShouldReturnNullAndLogError()
+    {
+        // Arrange
+        var setting = TestData.CreateSetting("InvalidJsonKey", "{ invalid json");
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _service.GetSettingAsync<TestModel>("InvalidJsonKey");
+
+        // Assert
+        result.Should().BeNull();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Failed to deserialize setting InvalidJsonKey")),
+                It.IsAny<JsonException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetSettingAsync_Generic_WithNonExistentKey_ShouldReturnNull()
+    {
+        // Act
+        var result = await _service.GetSettingAsync<TestModel>("NonExistentKey");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region GetSettingAsync With Default Value Tests
+
+    [Fact]
+    public async Task GetSettingAsync_WithDefaultValue_WhenSettingExists_ShouldReturnActualValue()
+    {
+        // Arrange
+        var setting = TestData.CreateSetting("ExistingKey", "ActualValue");
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _service.GetSettingAsync("ExistingKey", "DefaultValue");
+
+        // Assert
+        result.Should().Be("ActualValue");
+    }
+
+    [Fact]
+    public async Task GetSettingAsync_WithDefaultValue_WhenSettingDoesNotExist_ShouldReturnDefaultValue()
+    {
+        // Act
+        var result = await _service.GetSettingAsync("NonExistentKey", "DefaultValue");
+
+        // Assert
+        result.Should().Be("DefaultValue");
+    }
+
+    #endregion
+
+    #region GetSettingsByCategoryAsync Tests
+
+    [Fact]
+    public async Task GetSettingsByCategoryAsync_WithValidCategory_ShouldReturnCategorySettings()
+    {
+        // Arrange
+        var settings = new[]
+        {
+            TestData.CreateSetting("Key1", "Value1", "General"),
+            TestData.CreateSetting("Key2", "Value2", "Security"),
+            TestData.CreateSetting("Key3", "Value3", "General"),
+            TestData.CreateSetting("Key4", "Value4", "General", isActive: false)
+        };
+        _context.ApplicationSettings.AddRange(settings);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _service.GetSettingsByCategoryAsync("General");
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().ContainKeys("Key1", "Key3");
+        result["Key1"].Should().Be("Value1");
+        result["Key3"].Should().Be("Value3");
+    }
+
+    [Fact]
+    public async Task GetSettingsByCategoryAsync_WithNonExistentCategory_ShouldReturnEmptyDictionary()
+    {
+        // Act
+        var result = await _service.GetSettingsByCategoryAsync("NonExistentCategory");
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetSettingsByCategoryAsync_WithNullOrEmptyCategory_ShouldThrowArgumentException()
+    {
+        // Act & Assert
+        var act1 = async () => await _service.GetSettingsByCategoryAsync(null!);
+        var act2 = async () => await _service.GetSettingsByCategoryAsync("");
+        var act3 = async () => await _service.GetSettingsByCategoryAsync("   ");
+
+        await act1.Should().ThrowAsync<ArgumentException>().WithMessage("*Category cannot be null or empty*");
+        await act2.Should().ThrowAsync<ArgumentException>().WithMessage("*Category cannot be null or empty*");
+        await act3.Should().ThrowAsync<ArgumentException>().WithMessage("*Category cannot be null or empty*");
+    }
+
+    #endregion
+
+    #region GetAllSettingsAsync Tests
+
+    [Fact]
+    public async Task GetAllSettingsAsync_ShouldReturnAllActiveSettings()
+    {
+        // Arrange
+        var settings = new[]
+        {
+            TestData.CreateSetting("Key1", "Value1", "General"),
+            TestData.CreateSetting("Key2", "Value2", "Security"),
+            TestData.CreateSetting("Key3", "Value3", "General", isActive: false)
+        };
+        _context.ApplicationSettings.AddRange(settings);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _service.GetAllSettingsAsync();
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().ContainKeys("Key1", "Key2");
+        result["Key1"].Should().Be("Value1");
+        result["Key2"].Should().Be("Value2");
+    }
+
+    [Fact]
+    public async Task GetAllSettingsAsync_WithNoSettings_ShouldReturnEmptyDictionary()
+    {
+        // Act
+        var result = await _service.GetAllSettingsAsync();
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region SetSettingAsync Tests
+
+    [Fact]
+    public async Task SetSettingAsync_WithNewSetting_ShouldCreateSetting()
+    {
+        // Act
+        await _service.SetSettingAsync("NewKey", "NewValue", "New Description", "NewCategory", "TestUser");
+
+        // Assert
+        var setting = await _context.ApplicationSettings.FirstOrDefaultAsync(s => s.Key == "NewKey");
+        setting.Should().NotBeNull();
+        setting!.Value.Should().Be("NewValue");
+        setting.Description.Should().Be("New Description");
+        setting.Category.Should().Be("NewCategory");
+        setting.CreatedBy.Should().Be("TestUser");
+        setting.UpdatedBy.Should().Be("TestUser");
+        setting.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SetSettingAsync_WithExistingSetting_ShouldUpdateSetting()
+    {
+        // Arrange
+        var existingSetting = TestData.CreateSetting("ExistingKey", "OldValue", "OldCategory", "Old Description");
+        _context.ApplicationSettings.Add(existingSetting);
+        await _context.SaveChangesAsync();
+
+        // Act
+        await _service.SetSettingAsync("ExistingKey", "NewValue", "New Description", "NewCategory", "TestUser");
+
+        // Assert
+        var setting = await _context.ApplicationSettings.FirstOrDefaultAsync(s => s.Key == "ExistingKey");
+        setting.Should().NotBeNull();
+        setting!.Value.Should().Be("NewValue");
+        setting.Description.Should().Be("New Description");
+        setting.Category.Should().Be("NewCategory");
+        setting.UpdatedBy.Should().Be("TestUser");
+        setting.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SetSettingAsync_WithNullOrEmptyKey_ShouldThrowArgumentException()
+    {
+        // Act & Assert
+        var act1 = async () => await _service.SetSettingAsync(null!, "Value");
+        var act2 = async () => await _service.SetSettingAsync("", "Value");
+        var act3 = async () => await _service.SetSettingAsync("   ", "Value");
+
+        await act1.Should().ThrowAsync<ArgumentException>().WithMessage("*Setting key cannot be null or empty*");
+        await act2.Should().ThrowAsync<ArgumentException>().WithMessage("*Setting key cannot be null or empty*");
+        await act3.Should().ThrowAsync<ArgumentException>().WithMessage("*Setting key cannot be null or empty*");
+    }
+
+    [Fact]
+    public async Task SetSettingAsync_WithNullValue_ShouldThrowArgumentNullException()
+    {
+        // Act & Assert
+        var act = async () => await _service.SetSettingAsync("Key", null!);
+        await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("value");
+    }
+
+    [Fact]
+    public async Task SetSettingAsync_ShouldInvalidateCache()
+    {
+        // Arrange
+        var setting = TestData.CreateSetting("CacheKey", "OldValue");
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // Cache the value
+        await _service.GetSettingAsync("CacheKey");
+
+        // Act
+        await _service.SetSettingAsync("CacheKey", "NewValue");
+
+        // Assert
+        var result = await _service.GetSettingAsync("CacheKey");
+        result.Should().Be("NewValue");
+    }
+
+    [Fact]
+    public async Task SetSettingAsync_ShouldLogInformation()
+    {
+        // Act
+        await _service.SetSettingAsync("TestKey", "TestValue", updatedBy: "TestUser");
+
+        // Assert
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Setting TestKey updated by TestUser")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region SetSettingsAsync Tests
+
+    [Fact]
+    public async Task SetSettingsAsync_WithMultipleSettings_ShouldSetAllSettings()
+    {
+        // Arrange
+        var settings = new Dictionary<string, string>
+        {
+            { "Key1", "Value1" },
+            { "Key2", "Value2" },
+            { "Key3", "Value3" }
+        };
+
+        // Act
+        await _service.SetSettingsAsync(settings, "TestCategory", "TestUser");
+
+        // Assert
+        var savedSettings = await _context.ApplicationSettings.ToListAsync();
+        savedSettings.Should().HaveCount(3);
+        savedSettings.All(s => s.Category == "TestCategory").Should().BeTrue();
+        savedSettings.All(s => s.CreatedBy == "TestUser").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SetSettingsAsync_WithNullOrEmptyDictionary_ShouldDoNothing()
+    {
+        // Act
+        await _service.SetSettingsAsync(null!);
+        await _service.SetSettingsAsync(new Dictionary<string, string>());
+
+        // Assert
+        var settings = await _context.ApplicationSettings.ToListAsync();
+        settings.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region DeleteSettingAsync Tests
+
+    [Fact]
+    public async Task DeleteSettingAsync_WithExistingSetting_ShouldSoftDeleteSetting()
+    {
+        // Arrange
+        var setting = TestData.CreateSetting("DeleteKey", "DeleteValue");
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // Act
+        await _service.DeleteSettingAsync("DeleteKey");
+
+        // Assert
+        var deletedSetting = await _context.ApplicationSettings.FirstOrDefaultAsync(s => s.Key == "DeleteKey");
+        deletedSetting.Should().NotBeNull();
+        deletedSetting!.IsActive.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeleteSettingAsync_WithNonExistentSetting_ShouldDoNothing()
+    {
+        // Arrange
+        var initialCount = await _context.ApplicationSettings.CountAsync();
+
+        // Act
+        await _service.DeleteSettingAsync("NonExistentKey");
+
+        // Assert
+        var finalCount = await _context.ApplicationSettings.CountAsync();
+        finalCount.Should().Be(initialCount, "database should remain unchanged");
+
+        // Verify no delete logging occurred
+        _mockLogger.Verify(
+            x => x.Log(LogLevel.Information, It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("deleted")),
+                It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteSettingAsync_WithNullOrEmptyKey_ShouldDoNothing()
+    {
+        // Arrange
+        var existingSetting = TestData.CreateSetting("TestKey", "TestValue");
+        _context.ApplicationSettings.Add(existingSetting);
+        await _context.SaveChangesAsync();
+
+        var initialCount = await _context.ApplicationSettings.CountAsync();
+
+        // Act - Test all invalid key scenarios
+        await _service.DeleteSettingAsync(null!);
+        await _service.DeleteSettingAsync("");
+        await _service.DeleteSettingAsync("   ");
+
+        // Assert
+        var finalCount = await _context.ApplicationSettings.CountAsync();
+        finalCount.Should().Be(initialCount, "database should remain unchanged for invalid keys");
+
+        // Verify existing setting is unchanged
+        var setting = await _context.ApplicationSettings.FirstAsync(s => s.Key == "TestKey");
+        setting.IsActive.Should().BeTrue("existing setting should remain active");
+
+        // Verify no delete logging occurred
+        _mockLogger.Verify(
+            x => x.Log(LogLevel.Information, It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("deleted")),
+                It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteSettingAsync_ShouldInvalidateCache()
+    {
+        // Arrange
+        var setting = TestData.CreateSetting("CacheDeleteKey", "CacheDeleteValue");
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // Cache the value
+        await _service.GetSettingAsync("CacheDeleteKey");
+
+        // Act
+        await _service.DeleteSettingAsync("CacheDeleteKey");
+
+        // Assert
+        var result = await _service.GetSettingAsync("CacheDeleteKey");
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region SettingExistsAsync Tests
+
+    [Fact]
+    public async Task SettingExistsAsync_WithExistingActiveSetting_ShouldReturnTrue()
+    {
+        // Arrange
+        var setting = TestData.CreateSetting("ExistsKey", "ExistsValue");
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _service.SettingExistsAsync("ExistsKey");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SettingExistsAsync_WithExistingInactiveSetting_ShouldReturnFalse()
+    {
+        // Arrange
+        var setting = TestData.CreateSetting("InactiveExistsKey", "InactiveExistsValue", isActive: false);
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _service.SettingExistsAsync("InactiveExistsKey");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SettingExistsAsync_WithNonExistentSetting_ShouldReturnFalse()
+    {
+        // Act
+        var result = await _service.SettingExistsAsync("NonExistentKey");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SettingExistsAsync_WithNullOrEmptyKey_ShouldReturnFalse()
+    {
+        // Act & Assert
+        var result1 = await _service.SettingExistsAsync(null!);
+        var result2 = await _service.SettingExistsAsync("");
+        var result3 = await _service.SettingExistsAsync("   ");
+
+        result1.Should().BeFalse();
+        result2.Should().BeFalse();
+        result3.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region RefreshCacheAsync Tests
+
+    [Fact]
+    public async Task RefreshCacheAsync_WithCachingEnabled_ShouldCacheAllActiveSettings()
+    {
+        // Arrange
+        var settings = new[]
+        {
+            TestData.CreateSetting("Key1", "Value1"),
+            TestData.CreateSetting("Key2", "Value2"),
+            TestData.CreateSetting("Key3", "Value3", isActive: false)
+        };
+        _context.ApplicationSettings.AddRange(settings);
+        await _context.SaveChangesAsync();
+
+        // Act
+        await _service.RefreshCacheAsync();
+
+        // Remove settings from database to test cache
+        _context.ApplicationSettings.RemoveRange(settings);
+        await _context.SaveChangesAsync();
+
+        // Assert - should still get values from cache
+        var result1 = await _service.GetSettingAsync("Key1");
+        var result2 = await _service.GetSettingAsync("Key2");
+        var result3 = await _service.GetSettingAsync("Key3");
+
+        result1.Should().Be("Value1");
+        result2.Should().Be("Value2");
+        result3.Should().BeNull(); // Inactive setting should not be cached
+    }
+
+    [Fact]
+    public async Task RefreshCacheAsync_WithCachingDisabled_ShouldDoNothing()
+    {
+        // Arrange
+        _options.EnableCaching = false;
+        var service = new ExistingContextApplicationSettingsService<TestDbContext>(
+            _context, _cache, Options.Create(_options), _mockLogger.Object);
+
+        var setting = TestData.CreateSetting("CacheDisabledKey", "CacheDisabledValue");
+        _context.ApplicationSettings.Add(setting);
+        await _context.SaveChangesAsync();
+
+        // Act
+        await service.RefreshCacheAsync();
+
+        // Remove setting from database
+        _context.ApplicationSettings.Remove(setting);
+        await _context.SaveChangesAsync();
+
+        // Assert
+        var result = await service.GetSettingAsync("CacheDisabledKey");
+        result.Should().BeNull(); // Should not be cached
+    }
+
+    #endregion
+
+    #region Helper Classes and Methods
+
+    private static TestDbContext CreateTestDbContext()
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        return new TestDbContext(options);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _cache.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    #endregion
+}
+
+// Test DbContext for testing ExistingContextApplicationSettingsService
+public class TestDbContext : DbContext
+{
+    public TestDbContext(DbContextOptions<TestDbContext> options) : base(options) { }
+
+    public DbSet<ApplicationSetting> ApplicationSettings => Set<ApplicationSetting>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<ApplicationSetting>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.HasIndex(e => e.Key).IsUnique().HasDatabaseName("IX_ApplicationSettings_Key");
+            entity.Property(e => e.Key).IsRequired().HasMaxLength(200);
+            entity.Property(e => e.Value).IsRequired();
+            entity.Property(e => e.Category).HasMaxLength(100);
+            entity.Property(e => e.Description).HasMaxLength(500);
+            entity.Property(e => e.CreatedBy).HasMaxLength(100);
+            entity.Property(e => e.UpdatedBy).HasMaxLength(100);
+        });
+    }
+}
+
+// Test model for JSON deserialization tests
+public class TestModel
+{
+    public string Name { get; set; } = string.Empty;
+    public int Value { get; set; }
+}

--- a/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/GlobalUsings.cs
+++ b/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests.csproj
+++ b/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests.csproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GovUK.Dfe.CoreLibs.Utilities" Version="1.0.16" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+	  <PackageReference Include="FluentAssertions" Version="7.0.0" />
+	  <PackageReference Include="Moq" Version="4.20.72" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.14" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\GovUK.Dfe.CoreLibs.ApplicationSettings\GovUK.Dfe.CoreLibs.ApplicationSettings.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/ServiceCollectionExtensionsTests.cs
+++ b/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,458 @@
+﻿using FluentAssertions;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Configuration;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Data;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Extensions;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Interfaces;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace GovUK.Dfe.CoreLibs.ApplicationSettings.Tests.Extensions;
+
+public class ServiceCollectionExtensionsTests
+{
+    private readonly IServiceCollection _services;
+    private readonly IConfiguration _configuration;
+
+    public ServiceCollectionExtensionsTests()
+    {
+        _services = new ServiceCollection();
+        _services.AddLogging();
+        _configuration = CreateTestConfiguration();
+    }
+
+    #region AddApplicationSettings with IConfiguration Tests
+
+    [Fact]
+    public void AddApplicationSettings_WithConfiguration_ShouldRegisterAllServices()
+    {
+        // Act
+        _services.AddApplicationSettings(_configuration);
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Assert
+        serviceProvider.GetService<IApplicationSettingsService>().Should().NotBeNull();
+        serviceProvider.GetService<ApplicationSettingsDbContext>().Should().NotBeNull();
+        serviceProvider.GetService<IMemoryCache>().Should().NotBeNull();
+        serviceProvider.GetService<IOptions<ApplicationSettingsOptions>>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddApplicationSettings_WithConfiguration_ShouldRegisterCorrectImplementation()
+    {
+        // Act
+        _services.AddApplicationSettings(_configuration);
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Assert
+        var service = serviceProvider.GetService<IApplicationSettingsService>();
+        service.Should().BeOfType<ApplicationSettingsService>();
+    }
+
+    [Fact]
+    public void AddApplicationSettings_WithConfigurationAndCustomConnectionString_ShouldUseCustomConnectionString()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "ConnectionStrings:CustomConnection", "Server=custom;Database=CustomDb;" }
+            })
+            .Build();
+
+        // Act
+        _services.AddApplicationSettings(config, "CustomConnection");
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Assert
+        var dbContext = serviceProvider.GetService<ApplicationSettingsDbContext>();
+        dbContext.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddApplicationSettings_WithConfigurationAndSchema_ShouldSetSchema()
+    {
+        // Act
+        _services.AddApplicationSettings(_configuration, schema: "CustomSchema");
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Assert
+        var options = serviceProvider.GetService<IOptions<ApplicationSettingsOptions>>()?.Value;
+        options.Should().NotBeNull();
+        options!.Schema.Should().Be("CustomSchema");
+    }
+
+    [Fact]
+    public void AddApplicationSettings_WithConfigurationSection_ShouldReadFromConfiguration()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "ConnectionStrings:DefaultConnection", "Server=test;Database=TestDb;" },
+                { "ApplicationSettings:EnableCaching", "false" },
+                { "ApplicationSettings:CacheExpirationMinutes", "60" },
+                { "ApplicationSettings:DefaultCategory", "Custom" },
+                { "ApplicationSettings:EnableEncryption", "true" },
+                { "ApplicationSettings:EncryptionKey", "TestKey123" },
+                { "ApplicationSettings:Schema", "ConfigSchema" }
+            })
+            .Build();
+
+        // Act
+        _services.AddApplicationSettings(config);
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Assert
+        var options = serviceProvider.GetService<IOptions<ApplicationSettingsOptions>>()?.Value;
+        options.Should().NotBeNull();
+        options!.EnableCaching.Should().BeFalse();
+        options.CacheExpirationMinutes.Should().Be(60);
+        options.DefaultCategory.Should().Be("Custom");
+        options.Schema.Should().Be("ConfigSchema");
+    }
+
+    [Fact]
+    public void AddApplicationSettings_WithSchemaParameterOverridingConfig_ShouldUseParameterSchema()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "ConnectionStrings:DefaultConnection", "Server=test;Database=TestDb;" },
+                { "ApplicationSettings:Schema", "ConfigSchema" }
+            })
+            .Build();
+
+        // Act
+        _services.AddApplicationSettings(config, schema: "ParameterSchema");
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Assert
+        var options = serviceProvider.GetService<IOptions<ApplicationSettingsOptions>>()?.Value;
+        options.Should().NotBeNull();
+        options!.Schema.Should().Be("ParameterSchema");
+    }
+
+    [Fact]
+    public void AddApplicationSettings_WithInvalidConfigurationValues_ShouldUseDefaults()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "ConnectionStrings:DefaultConnection", "Server=test;Database=TestDb;" },
+                { "ApplicationSettings:EnableCaching", "invalid_bool" },
+                { "ApplicationSettings:CacheExpirationMinutes", "invalid_int" },
+                { "ApplicationSettings:EnableEncryption", "not_a_boolean" }
+            })
+            .Build();
+
+        // Act
+        _services.AddApplicationSettings(config);
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Assert
+        var options = serviceProvider.GetService<IOptions<ApplicationSettingsOptions>>()?.Value;
+        options.Should().NotBeNull();
+        options!.EnableCaching.Should().BeTrue(); // Default value
+        options.CacheExpirationMinutes.Should().Be(30); // Default value
+        options.DefaultCategory.Should().Be("General"); // Default value
+    }
+
+    [Fact]
+    public void AddApplicationSettings_ShouldReturnServiceCollection()
+    {
+        // Act
+        var result = _services.AddApplicationSettings(_configuration);
+
+        // Assert
+        result.Should().BeSameAs(_services);
+    }
+
+    #endregion
+
+    #region AddApplicationSettingsWithExistingContext Tests
+
+    [Fact]
+    public void AddApplicationSettingsWithExistingContext_ShouldRegisterCorrectImplementation()
+    {
+        // Arrange - Register the TestDbContext in the DI container
+        _services.AddDbContext<TestDbContext>(options =>
+            options.UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString()));
+
+        // Act
+        _services.AddApplicationSettingsWithExistingContext<TestDbContext>(_configuration);
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Assert
+        var service = serviceProvider.GetService<IApplicationSettingsService>();
+        service.Should().BeOfType<ExistingContextApplicationSettingsService<TestDbContext>>();
+    }
+
+    [Fact]
+    public void AddApplicationSettingsWithExistingContext_ShouldNotRegisterDbContext()
+    {
+        // Arrange - Register the TestDbContext in the DI container
+        _services.AddDbContext<TestDbContext>(options =>
+            options.UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString()));
+
+        // Act
+        _services.AddApplicationSettingsWithExistingContext<TestDbContext>(_configuration);
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Assert - Should not register ApplicationSettingsDbContext since we're using existing context
+        var applicationSettingsDbContext = serviceProvider.GetService<ApplicationSettingsDbContext>();
+        applicationSettingsDbContext.Should().BeNull();
+    }
+
+    [Fact]
+    public void AddApplicationSettingsWithExistingContext_ShouldRegisterMemoryCache()
+    {
+        // Arrange - Register the TestDbContext in the DI container
+        _services.AddDbContext<TestDbContext>(options =>
+            options.UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString()));
+
+        // Act
+        _services.AddApplicationSettingsWithExistingContext<TestDbContext>(_configuration);
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Assert
+        var memoryCache = serviceProvider.GetService<IMemoryCache>();
+        memoryCache.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddApplicationSettingsWithExistingContext_WithConfiguration_ShouldReadFromConfiguration()
+    {
+        // Arrange
+        _services.AddDbContext<TestDbContext>(options =>
+            options.UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString()));
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "ApplicationSettings:EnableCaching", "false" },
+                { "ApplicationSettings:CacheExpirationMinutes", "45" },
+                { "ApplicationSettings:DefaultCategory", "ExistingContext" },
+                { "ApplicationSettings:EnableEncryption", "true" },
+                { "ApplicationSettings:EncryptionKey", "ExistingKey123" }
+            })
+            .Build();
+
+        // Act
+        _services.AddApplicationSettingsWithExistingContext<TestDbContext>(config);
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Assert
+        var options = serviceProvider.GetService<IOptions<ApplicationSettingsOptions>>()?.Value;
+        options.Should().NotBeNull();
+        options!.EnableCaching.Should().BeFalse();
+        options.CacheExpirationMinutes.Should().Be(45);
+        options.DefaultCategory.Should().Be("ExistingContext");
+    }
+
+    [Fact]
+    public void AddApplicationSettingsWithExistingContext_WithSchema_ShouldSetSchema()
+    {
+        // Arrange - Register the TestDbContext in the DI container
+        _services.AddDbContext<TestDbContext>(options =>
+            options.UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString()));
+
+        // Act
+        _services.AddApplicationSettingsWithExistingContext<TestDbContext>(_configuration, "ExistingSchema");
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Assert
+        var options = serviceProvider.GetService<IOptions<ApplicationSettingsOptions>>()?.Value;
+        options.Should().NotBeNull();
+        options!.Schema.Should().Be("ExistingSchema");
+    }
+
+    [Fact]
+    public void AddApplicationSettingsWithExistingContext_ShouldReturnServiceCollection()
+    {
+        // Act
+        var result = _services.AddApplicationSettingsWithExistingContext<TestDbContext>(_configuration);
+
+        // Assert
+        result.Should().BeSameAs(_services);
+    }
+
+    [Fact]
+    public void AddApplicationSettingsWithExistingContext_ShouldRegisterServiceWithCorrectLifetime()
+    {
+        // Arrange - Register the TestDbContext in the DI container
+        _services.AddDbContext<TestDbContext>(options =>
+            options.UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString()));
+
+        // Act
+        _services.AddApplicationSettingsWithExistingContext<TestDbContext>(_configuration);
+
+        // Assert
+        var serviceDescriptor = _services.FirstOrDefault(s => s.ServiceType == typeof(IApplicationSettingsService));
+        serviceDescriptor.Should().NotBeNull();
+        serviceDescriptor!.Lifetime.Should().Be(ServiceLifetime.Scoped);
+        serviceDescriptor.ImplementationType.Should().Be(typeof(ExistingContextApplicationSettingsService<TestDbContext>));
+    }
+
+    #endregion
+
+    #region AddApplicationSettings with ConnectionString Tests
+
+    [Fact]
+    public void AddApplicationSettings_WithConnectionString_ShouldRegisterAllServices()
+    {
+        // Arrange
+        const string connectionString = "Server=test;Database=TestDb;";
+
+        // Act
+        _services.AddApplicationSettings(connectionString);
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Assert
+        serviceProvider.GetService<IApplicationSettingsService>().Should().NotBeNull();
+        serviceProvider.GetService<ApplicationSettingsDbContext>().Should().NotBeNull();
+        serviceProvider.GetService<IMemoryCache>().Should().NotBeNull();
+        serviceProvider.GetService<IOptions<ApplicationSettingsOptions>>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddApplicationSettings_WithConnectionString_ShouldUseDefaultOptions()
+    {
+        // Arrange
+        const string connectionString = "Server=test;Database=TestDb;";
+
+        // Act
+        _services.AddApplicationSettings(connectionString);
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Assert
+        var options = serviceProvider.GetService<IOptions<ApplicationSettingsOptions>>()?.Value;
+        options.Should().NotBeNull();
+        options!.EnableCaching.Should().BeTrue();
+        options.CacheExpirationMinutes.Should().Be(30);
+        options.DefaultCategory.Should().Be("General");
+        options.Schema.Should().BeNull();
+    }
+
+    [Fact]
+    public void AddApplicationSettings_WithConnectionStringAndConfigureOptions_ShouldApplyCustomConfiguration()
+    {
+        // Arrange
+        const string connectionString = "Server=test;Database=TestDb;";
+
+        // Act
+        _services.AddApplicationSettings(connectionString, options =>
+        {
+            options.EnableCaching = false;
+            options.CacheExpirationMinutes = 120;
+            options.DefaultCategory = "CustomCategory";
+            options.Schema = "CustomSchema";
+        });
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Assert
+        var options = serviceProvider.GetService<IOptions<ApplicationSettingsOptions>>()?.Value;
+        options.Should().NotBeNull();
+        options!.EnableCaching.Should().BeFalse();
+        options.CacheExpirationMinutes.Should().Be(120);
+        options.DefaultCategory.Should().Be("CustomCategory");
+        options.Schema.Should().Be("CustomSchema");
+    }
+
+    [Fact]
+    public void AddApplicationSettings_WithConnectionStringAndNullConfigureOptions_ShouldUseDefaults()
+    {
+        // Arrange
+        const string connectionString = "Server=test;Database=TestDb;";
+
+        // Act
+        _services.AddApplicationSettings(connectionString, null);
+        var serviceProvider = _services.BuildServiceProvider();
+
+        // Assert
+        var options = serviceProvider.GetService<IOptions<ApplicationSettingsOptions>>()?.Value;
+        options.Should().NotBeNull();
+        options!.EnableCaching.Should().BeTrue();
+        options.CacheExpirationMinutes.Should().Be(30);
+        options.DefaultCategory.Should().Be("General");
+        options.Schema.Should().BeNull();
+    }
+
+    [Fact]
+    public void AddApplicationSettings_WithConnectionString_ShouldReturnServiceCollection()
+    {
+        // Arrange
+        const string connectionString = "Server=test;Database=TestDb;";
+
+        // Act
+        var result = _services.AddApplicationSettings(connectionString);
+
+        // Assert
+        result.Should().BeSameAs(_services);
+    }
+
+    #endregion
+
+    #region Service Registration Tests
+
+    [Fact]
+    public void AddApplicationSettings_ShouldRegisterServicesWithCorrectLifetime()
+    {
+        // Act
+        _services.AddApplicationSettings(_configuration);
+
+        // Assert
+        var serviceDescriptor = _services.FirstOrDefault(s => s.ServiceType == typeof(IApplicationSettingsService));
+        serviceDescriptor.Should().NotBeNull();
+        serviceDescriptor!.Lifetime.Should().Be(ServiceLifetime.Scoped);
+
+        var dbContextDescriptor = _services.FirstOrDefault(s => s.ServiceType == typeof(ApplicationSettingsDbContext));
+        dbContextDescriptor.Should().NotBeNull();
+        dbContextDescriptor!.Lifetime.Should().Be(ServiceLifetime.Scoped);
+    }
+
+    [Fact]
+    public void AddApplicationSettings_CalledMultipleTimes_ShouldNotDuplicateMemoryCache()
+    {
+        // Act
+        _services.AddApplicationSettings(_configuration);
+        _services.AddApplicationSettings(_configuration);
+
+        // Assert
+        var memoryCacheDescriptors = _services.Where(s => s.ServiceType == typeof(IMemoryCache)).ToList();
+        memoryCacheDescriptors.Should().HaveCount(1, "MemoryCache should only be registered once");
+    }
+
+    #endregion
+
+    #region Helper Methods and Classes
+
+    private static IConfiguration CreateTestConfiguration()
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "ConnectionStrings:DefaultConnection", "Server=test;Database=TestDb;" }
+            })
+            .Build();
+    }
+
+    #endregion
+}
+
+// Test DbContext for testing existing context scenarios
+public class TestDbContext : DbContext
+{
+    public TestDbContext(DbContextOptions<TestDbContext> options) : base(options) { }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        // Add any necessary model configuration here
+    }
+}

--- a/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/TestHelpers/TestData.cs
+++ b/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/TestHelpers/TestData.cs
@@ -1,0 +1,36 @@
+﻿using GovUK.Dfe.CoreLibs.ApplicationSettings.Entities;
+
+namespace GovUK.Dfe.CoreLibs.ApplicationSettings.Tests.TestHelpers;
+
+public static class TestData
+{
+    public static ApplicationSetting CreateSetting(
+        string key = "TestKey",
+        string value = "TestValue",
+        string category = "General",
+        string? description = null,
+        bool isActive = true)
+    {
+        return new ApplicationSetting
+        {
+            Key = key,
+            Value = value,
+            Category = category,
+            Description = description,
+            IsActive = isActive,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+    }
+
+    public static List<ApplicationSetting> CreateMultipleSettings()
+    {
+        return new List<ApplicationSetting>
+        {
+            CreateSetting("Setting1", "Value1", "General"),
+            CreateSetting("Setting2", "Value2", "Security"),
+            CreateSetting("Setting3", "Value3", "General"),
+            CreateSetting("InactiveSetting", "InactiveValue", "General", isActive: false)
+        };
+    }
+}

--- a/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/TestHelpers/TestDbContextFactory.cs
+++ b/src/Tests/GovUK.Dfe.CoreLibs.ApplicationSettings.Tests/TestHelpers/TestDbContextFactory.cs
@@ -1,0 +1,26 @@
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Configuration;
+using GovUK.Dfe.CoreLibs.ApplicationSettings.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace GovUK.Dfe.CoreLibs.ApplicationSettings.Tests.TestHelpers;
+
+public static class TestDbContextFactory
+{
+    public static ApplicationSettingsDbContext CreateInMemoryContext(string? schema = null)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationSettingsDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        var settingsOptions = Options.Create(new ApplicationSettingsOptions
+        {
+            Schema = schema,
+            EnableCaching = true,
+            CacheExpirationMinutes = 30,
+            DefaultCategory = "General"
+        });
+
+        return new ApplicationSettingsDbContext(options, settingsOptions);
+    }
+}


### PR DESCRIPTION
#### PR Classification
Introduces a new feature by adding a reusable, database-backed application settings library with full test coverage and CI integration.

#### PR Summary
Implements GovUK.Dfe.CoreLibs.ApplicationSettings for managing application settings via EF Core, with DI support, caching, and comprehensive tests.
- Adds core library files: `ApplicationSetting` entity, `ApplicationSettingsDbContext`, configuration options, and DI/service extensions.
- Implements service logic for retrieving, updating, and caching settings (`ApplicationSettingsService`, `ExistingContextApplicationSettingsService`, `BaseApplicationSettingsService`).
- Provides extension methods for easy integration with existing DbContexts (`DbContextExtensions`, `ServiceCollectionExtensions`).
- Adds a full test suite covering all core components and DI registration.
- Includes a detailed README and GitHub Actions workflow for CI and package publishing.
